### PR TITLE
Revert "Upgrading consul-template to 0.9.0"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM gliderlabs/alpine
 
 MAINTAINER Steven Borrelli <steve@aster.is>
 
-ENV CONSUL_TEMPLATE_VERSION=0.9.0
+ENV CONSUL_TEMPLATE_VERSION=0.8.0
 
 RUN apk-install bash haproxy ca-certificates
 


### PR DESCRIPTION
Revert consul-template 0.9.0 due to stability issues found in testing.

Reverts CiscoCloud/haproxy-consul#3
