### PR TITLE
Provide SSL support, and permit container restarts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ For example:
 docker run -v /etc/ssl/wildcard.example.com.pem:/haproxy/ssl.crt -e HAPROXY_USESSL=true -e HAPROXY_DOMAIN=example.com --net=host --name=haproxy haproxy-consul
 ```
 
+You can also force that all incoming connections are redirected to HTTPS, by setting `HAPROXY_USESSL=force`.
+
 SSL termination is currently only available in 'consul' mode.
 
 # License

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Dynamic haproxy configuration using consul packed into a Docker container that w
             - [Marathon Configuration](#marathon-configuration)
         - [Usage](#usage)
     - [Options](#options)
-        - [SSL Termination](#ssl)
+        - [SSL Termination](#ssl-termination)
 - [License](#license)
 
 <!-- markdown-toc end -->
@@ -180,7 +180,7 @@ Variable | Description | Default
 ---------|-------------|---------
 `HAPROXY_DOMAIN` | The domain to match against | `haproxy.service.consul` (for `app.haproxy.service.consul`).
 `HAPROXY_MODE` | forward consul service or Marathon apps | `consul` (`marathon` also available, as described [above](#modes))
-`HAPROXY_USESSL` | Enable the SSL frontend (see [below](#ssl)) | `false`
+`HAPROXY_USESSL` | Enable the SSL frontend (see [below](#ssl-termination)) | `false`
 
 consul-template variables:
 
@@ -201,11 +201,11 @@ Variable | Description | Default
 `service/haproxy/timeouts/client` | client timeout | 50000ms
 `service/haproxy/timeouts/server` | server timeout | 50000ms
 
-## SSL Termination
+### SSL Termination
 
 If you wish to configure HAproxy to terminate incoming SSL connections, you must set the environment variable `HAPROXY_USESSL=true`, and mount your SSL certificate at `/haproxy/ssl.crt` - this file should contain both the SSL certificate and the private key to use (with no passphrase), in PEM format. You should also include any intermediate certificates in this bundle.
 
-If you do not provide an SSL certificate at container runtime, a self-signed certificate will be generated for the value of `HAPROXY_DOMAIN`.
+If you do not provide an SSL certificate at container runtime, a self-signed certificate will be generated for the value of `*.HAPROXY_DOMAIN`.
 
 For example:
 ```

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Dynamic haproxy configuration using consul packed into a Docker container that w
             - [Marathon Configuration](#marathon-configuration)
         - [Usage](#usage)
     - [Options](#options)
+        - [SSL Termination](#ssl)
 - [License](#license)
 
 <!-- markdown-toc end -->
@@ -179,6 +180,7 @@ Variable | Description | Default
 ---------|-------------|---------
 `HAPROXY_DOMAIN` | The domain to match against | `haproxy.service.consul` (for `app.haproxy.service.consul`).
 `HAPROXY_MODE` | forward consul service or Marathon apps | `consul` (`marathon` also available, as described [above](#modes))
+`HAPROXY_USESSL` | Enable the SSL frontend (see [below](#ssl)) | `false`
 
 consul-template variables:
 
@@ -198,6 +200,19 @@ Variable | Description | Default
 `service/haproxy/timeouts/connect` | connect timeout | 5000ms
 `service/haproxy/timeouts/client` | client timeout | 50000ms
 `service/haproxy/timeouts/server` | server timeout | 50000ms
+
+## SSL Termination
+
+If you wish to configure HAproxy to terminate incoming SSL connections, you must set the environment variable `HAPROXY_USESSL=true`, and mount your SSL certificate at `/haproxy/ssl.crt` - this file should contain both the SSL certificate and the private key to use (with no passphrase), in PEM format. You should also include any intermediate certificates in this bundle.
+
+If you do not provide an SSL certificate at container runtime, a self-signed certificate will be generated for the value of `HAPROXY_DOMAIN`.
+
+For example:
+```
+docker run -v /etc/ssl/wildcard.example.com.pem:/haproxy/ssl.crt -e HAPROXY_USESSL=true -e HAPROXY_DOMAIN=example.com --net=host --name=haproxy haproxy-consul
+```
+
+SSL termination is currently only available in 'consul' mode.
 
 # License
 

--- a/launch.sh
+++ b/launch.sh
@@ -69,6 +69,14 @@ function launch_haproxy {
       cat /haproxy/cert.pem /haproxy/key.pem > /haproxy/ssl.crt
     fi
 
+    # Remove haproxy PID file, in case we're restarting
+    [ -f /var/run/haproxy.pid ] && rm /var/run/haproxy.pid
+
+    # Force a template regeneration on restart (if this file hasn't changed,
+    # consul-template won't run the 'optional command' and thus haproxy won't
+    # be started)
+    [ -f /haproxy/haproxy.cfg ] && rm /haproxy/haproxy.cfg
+
     ${CONSUL_TEMPLATE} -config ${CONSUL_CONFIG} \
                        -log-level ${CONSUL_LOGLEVEL} \
                        -wait ${CONSUL_MINWAIT}:${CONSUL_MAXWAIT} \

--- a/launch.sh
+++ b/launch.sh
@@ -57,8 +57,10 @@ function launch_haproxy {
 
     vars=$@
 
-    ln -s /consul-template/template.d/${HAPROXY_MODE}.tmpl \
-          /consul-template/template.d/haproxy.tmpl
+    if [ ! -f /consul-template/template.d/haproxy.tmpl ]; then
+      ln -s /consul-template/template.d/${HAPROXY_MODE}.tmpl \
+            /consul-template/template.d/haproxy.tmpl
+    fi
 
     ${CONSUL_TEMPLATE} -config ${CONSUL_CONFIG} \
                        -log-level ${CONSUL_LOGLEVEL} \

--- a/template/consul.tmpl
+++ b/template/consul.tmpl
@@ -45,5 +45,5 @@ frontend www-ssl
 {{ range services }}
 backend {{ .Name }}_backend
 {{ range service .Name }}
-   server {{ .Node }} {{ .Address }}:{{ .Port }}{{ end }}
+   server {{ .Node }}-{{ .Port }} {{ .Address }}:{{ .Port }}{{ end }}
 {{ end }}

--- a/template/consul.tmpl
+++ b/template/consul.tmpl
@@ -1,15 +1,26 @@
 global
     maxconn {{or (key "service/haproxy/maxconn") 256}}
     debug
+    # Recommended SSL ciphers as per https://hynek.me/articles/hardening-your-web-servers-ssl-ciphers/
+    ssl-default-bind-options no-sslv3
+    ssl-default-bind-ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS
+
+    ssl-default-server-options no-sslv3
+    ssl-default-server-ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS
+    tune.ssl.default-dh-param 2048
 
 defaults
     mode http
+    option forwardfor
+    option http-server-close
     timeout connect {{or (key "service/haproxy/timeouts/connect") "5000ms"}}
     timeout client {{or (key "service/haproxy/timeouts/client") "50000ms"}}
     timeout server {{or (key "service/haproxy/timeouts/server") "50000ms"}}
 
+### HTTP frontend ###
 frontend www
     bind *:80
+    reqadd X-Forwarded-Proto:\ http
 
     # Generated automatically by consul-template
 {{ range services }}
@@ -17,6 +28,20 @@ frontend www
     use_backend {{ .Name }}_backend if host_{{ .Name }}
 {{ end }}
 
+{{ if env "HAPROXY_USESSL" | parseBool }}
+### HTTPS/SSL frontend ###
+frontend www-ssl
+    bind *:443 ssl crt /haproxy/ssl.crt
+    reqadd X-Forwarded-Proto:\ https
+
+    # Generated automatically by consul-template
+{{ range services }}
+    acl host_{{ .Name }} hdr(host) -i {{ .Name }}.{{ or (env "HAPROXY_DOMAIN") "haproxy.service.consul" }} 
+    use_backend {{ .Name }}_backend if host_{{ .Name }}
+{{ end }}
+{{ end }}
+
+### Consul-configured backend services ###
 {{ range services }}
 backend {{ .Name }}_backend
 {{ range service .Name }}

--- a/template/consul.tmpl
+++ b/template/consul.tmpl
@@ -17,10 +17,16 @@ defaults
     timeout client {{or (key "service/haproxy/timeouts/client") "50000ms"}}
     timeout server {{or (key "service/haproxy/timeouts/server") "50000ms"}}
 
-### HTTP frontend ###
+### HTTP(S) frontend ###
 frontend www
     bind *:80
-    reqadd X-Forwarded-Proto:\ http
+    {{ if env "HAPROXY_USESSL" }}bind *:443 ssl crt /haproxy/ssl.crt{{ end }}
+
+    reqadd X-Forwarded-Proto:\ http if !{ ssl_fc }
+    reqadd X-Forwarded-Proto:\ https if { ssl_fc }
+    {{ if eq (env "HAPROXY_USESSL") "force" }}
+    # Redirect all non-secure connections to HTTPS
+    redirect scheme https if !{ ssl_fc }{{ end }}
 
     # Generated automatically by consul-template
 {{ range services }}
@@ -28,18 +34,6 @@ frontend www
     use_backend {{ .Name }}_backend if host_{{ .Name }}
 {{ end }}
 
-{{ if env "HAPROXY_USESSL" | parseBool }}
-### HTTPS/SSL frontend ###
-frontend www-ssl
-    bind *:443 ssl crt /haproxy/ssl.crt
-    reqadd X-Forwarded-Proto:\ https
-
-    # Generated automatically by consul-template
-{{ range services }}
-    acl host_{{ .Name }} hdr(host) -i {{ .Name }}.{{ or (env "HAPROXY_DOMAIN") "haproxy.service.consul" }} 
-    use_backend {{ .Name }}_backend if host_{{ .Name }}
-{{ end }}
-{{ end }}
 
 ### Consul-configured backend services ###
 {{ range services }}


### PR DESCRIPTION
Provide support for SSL termination on the HAproxy instance - either via a bindmounted SSL certificate/key bundle or through an automatically generated SSL certificate based on HAPROXY_DOMAIN. This feature is optional, and also only supported in the 'consul' template mode. Fixes #13.

This also fixes the issue around container being restarted. Fixes #10.
