### PR TITLE
Fix issue#25 to allow restart to work

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -57,7 +57,10 @@ function launch_haproxy {
 
     vars=$@
 
-    ln -s /consul-template/template.d/${HAPROXY_MODE}.tmpl \
+    # Remove any old generated haproxy.cfg"
+    rm -f /haproxy/haproxy.cfg
+
+    ln -f -s /consul-template/template.d/${HAPROXY_MODE}.tmpl \
           /consul-template/template.d/haproxy.tmpl
 
     ${CONSUL_TEMPLATE} -config ${CONSUL_CONFIG} \


### PR DESCRIPTION
This fixes issue https://github.com/CiscoCloud/haproxy-consul/issues/25 that prevents the container restarting after it has been stopped.
