### PR TITLE
Using exec to launch consul-template, in order to take PID 1.

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -77,7 +77,7 @@ function launch_haproxy {
     # be started)
     [ -f /haproxy/haproxy.cfg ] && rm /haproxy/haproxy.cfg
 
-    ${CONSUL_TEMPLATE} -config ${CONSUL_CONFIG} \
+    exec ${CONSUL_TEMPLATE} -config ${CONSUL_CONFIG} \
                        -log-level ${CONSUL_LOGLEVEL} \
                        -wait ${CONSUL_MINWAIT}:${CONSUL_MAXWAIT} \
                        -consul ${CONSUL_CONNECT} ${ctargs} ${vars}


### PR DESCRIPTION
This tiny modification makes consul-template takes PID 1 over the initial bash process, which allow a better signal management (docker stop/kill will be forwarded to consul-template wich will andle it nicely and stop the "runner" - aka haproxy).

Without this, the docker stop signal (SIGTERM) is not forwarded to consul-template by bash, and the process is killed (SIGKILL) by docker after 10 seconds (default timeout), which is not really clean.
