### PR TITLE
Added multidomain support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.3
 
 MAINTAINER Steven Borrelli <steve@aster.is>
 
-ENV CONSUL_TEMPLATE_VERSION=0.12.2
+ENV CONSUL_TEMPLATE_VERSION=0.14.0
 
 RUN apk update && \
     apk add bash haproxy ca-certificates zip && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV CONSUL_TEMPLATE_VERSION=0.14.0
 RUN mkdir -p /haproxy /consul-template/config.d /consul-template/template.d
 
 RUN apk update && \
-    apk add libnl3 wget bash haproxy ca-certificates zip && \
+    apk add libnl3 wget bash haproxy ca-certificates zip openssl && \
     rm -rf /var/cache/apk/*
 
 RUN wget -O /consul-template.zip https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION}/consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,14 @@ MAINTAINER Steven Borrelli <steve@aster.is>
 
 ENV CONSUL_TEMPLATE_VERSION=0.14.0
 
-RUN mkdir -p /haproxy /consul-template/config.d /consul-template/template.d /usr/local/bin/consul-template
+RUN mkdir -p /haproxy /consul-template/config.d /consul-template/template.d
 
 RUN apk update && \
     apk add bash haproxy ca-certificates zip && \
     rm -rf /var/cache/apk/*
 
 RUN wget -O /consul-template.zip https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION}/consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip && \
-    unzip /consul-template.zip -d /usr/local/bin/consul-template && \
+    unzip /consul-template.zip -d /usr/local/bin/ && \
     rm -rf /consul-template.zip
 
 ADD config/ /consul-template/config.d/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,17 +4,15 @@ MAINTAINER Steven Borrelli <steve@aster.is>
 
 ENV CONSUL_TEMPLATE_VERSION=0.14.0
 
+RUN mkdir -p /haproxy /consul-template/config.d /consul-template/template.d /usr/local/bin/consul-template
+
 RUN apk update && \
     apk add bash haproxy ca-certificates zip && \
     rm -rf /var/cache/apk/*
 
-ADD https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION}/consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip /
-
-RUN unzip /consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip  && \
-    mv /consul-template /usr/local/bin/consul-template && \
-    rm -rf /consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip
-
-RUN mkdir -p /haproxy /consul-template/config.d /consul-template/template.d
+RUN wget -O /consul-template.zip https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION}/consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip && \
+    unzip /consul-template.zip -d /usr/local/bin/consul-template && \
+    rm -rf /consul-template.zip
 
 ADD config/ /consul-template/config.d/
 ADD template/ /consul-template/template.d/

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,11 @@ ENV CONSUL_TEMPLATE_VERSION=0.14.0
 RUN mkdir -p /haproxy /consul-template/config.d /consul-template/template.d
 
 RUN apk update && \
-    apk add libnl3 bash haproxy ca-certificates zip && \
+    apk add libnl3 wget bash haproxy ca-certificates zip && \
     rm -rf /var/cache/apk/*
 
-ADD https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION}/consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip /consul-template.zip
-
-RUN unzip /consul-template.zip -d /usr/local/bin/ && \
+RUN wget -O /consul-template.zip https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION}/consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip && \
+    unzip /consul-template.zip -d /usr/local/bin/ && \
     rm -rf /consul-template.zip
 
 ADD config/ /consul-template/config.d/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # haproxy-consul
 
-Dynamic haproxy configuration using consul packed into a Docker container that weighs 18MB.
+Dynamic haproxy configuration using consul packed into a Docker container that weighs 24MB.
 
 <!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc/generate-toc again -->
 **Table of Contents**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # haproxy-consul
 
-Dynamic haproxy configuration using consul packed into a Docker container that weighs 24MB.
+Dynamic haproxy configuration using consul packed into a Docker container that weighs 32MB.
 
 <!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc/generate-toc again -->
 **Table of Contents**
@@ -64,8 +64,13 @@ This will make the webserver's 80 port accessible through request to `www.exampl
 ### Usage
 Start the container as follows:
 ```
-docker run --net=host --name=haproxy -d asteris/haproxy-consul
+docker run --net=host --name=haproxy -d auguster/haproxy-consul
 ```
+alternative way not sharing network stack with host:
+```
+docker run -d --name haproxy -p 80:80 -p 443:443 -e CONSUL_CONNECT=172.17.0.1:8500 auguster/haproxy-consul
+```
+
 Now that it is set up, connect to an app:
 ```
 curl -L http://myapp.mycompany.com
@@ -80,7 +85,7 @@ curl -L http://myapp.180.19.20.21.xip.io
 If you want to override the config and template files, mount a volume and set the `CONSUL_CONFIG` environment variable before launch. In docker this can be accomplished with the `-e` option:
 
 ```
-docker run -v /host/config:/my_config -e CONSUL_CONFIG=/my_config -net=host --name=haproxy -d asteris/haproxy-consul
+docker run -v /host/config:/my_config -e CONSUL_CONFIG=/my_config -net=host --name=haproxy -d auguster/haproxy-consul
 ```
 
 If you need to have a root CA added so you can connect to Consul over SSL, mount
@@ -102,7 +107,7 @@ If you wish to configure HAproxy to terminate incoming SSL connections, you must
 
 For example:
 ```
-docker run -v /etc/ssl/wildcard.example.com.pem:/certs/ssl.crt:ro --net=host --name=haproxy haproxy-consul
+docker run -v /etc/ssl/wildcard.example.com.pem:/certs/ssl.crt:ro --net=host --name=haproxy auguster/haproxy-consul
 ```
 SSL termination is currently only available in 'consul' mode.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# haproxy-consul
+# haproxy-consul [![](https://images.microbadger.com/badges/image/auguster/haproxy-consul.svg)](https://microbadger.com/images/auguster/cloud-config-server)
 
-Dynamic haproxy configuration using consul packed into a Docker container that weighs 33MB.
+Dynamic haproxy configuration using consul packed into a Docker container.
 
 # Overview
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # haproxy-consul
 
-Dynamic haproxy configuration using consul packed into a Docker container that weighs 24MB.
+Dynamic haproxy configuration using consul packed into a Docker container that weighs 33MB.
 
 # Overview
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # haproxy-consul
 
-Dynamic haproxy configuration using consul packed into a Docker container that weighs 32MB.
+Dynamic haproxy configuration using consul packed into a Docker container that weighs 24MB.
 
 <!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc/generate-toc again -->
 **Table of Contents**

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Dynamic haproxy configuration using consul packed into a Docker container that w
 - [haproxy-consul](#haproxy-consul)
 - [Overview](#overview)
     - [How it works](#how-it-works)
+    - [Service registration](#service-registration)
+        - [Registrator](#registrator)
+        - [Naming services](#naming-services)
     - [Building](#building)
     - [Running](#running)
-        - [Modes](#modes)
-            - [consul Configuration](#consul-configuration)
-            - [Marathon Configuration](#marathon-configuration)
         - [Usage](#usage)
     - [Options](#options)
         - [SSL Termination](#ssl-termination)
@@ -23,10 +23,9 @@ Dynamic haproxy configuration using consul packed into a Docker container that w
 # Overview
 
 This project combines [Alpine Linux](https://www.alpinelinux.org), [consul template](https://github.com/hashicorp/consul-template), and [haproxy](http://haproxy.org)
-to create a proxy that forwards traffic to apps registered in Marathon and forwarded with [marathon-consul](https://github.com/CiscoCloud/marathon-consul).
+to create a proxy that forwards traffic to apps registered in consul.
 
 ## How it works
-
 First, you must set up a wildcard dns (using something like CloudFlare or [xip.io](http://xip.io)). This means that if your domain is `example.com`, any request to  a `<name>.example.com` will resolve to the IP of your haproxy container.
 
 Inside the haproxy container, a header match is used to map `<application>.example.com` to the service registered in consul under `application`.
@@ -37,128 +36,41 @@ Inside the haproxy container, a header match is used to map `<application>.examp
 docker build -t haproxy .
 ```
 
+## Service registration
+### Registrator 
+Run a registrator to automatically add and remove services.
+The best option so far is to run [gliderlabs/registrator](https://github.com/gliderlabs/registrator) container through the following command.
+```
+docker run -d --net host --name registrator -v /var/run/docker.sock:/tmp/docker.sock gliderlabs/registrator consul://127.0.0.1:8500
+```
+An other way to run it, without net host is:
+```
+docker run -d --name registrator -v /var/run/docker.sock:/tmp/docker.sock gliderlabs/registrator consul://172.17.0.1:8500
+```
+### Naming services
+The service can be declared through the environment variables `SERVICE_NAME` and `SERVICE_TAGS`.
+
+The `SERVICE_NAME` or `SERVICE_<port>_NAME` is the actual name you want to give to the service. It will be the subdomain of your requests: `<SERVICE_NAME>.domain.tld`.
+
+The domain can be specified using `SERVICE_TAGS` using the followind syntax: `<domain>_<tld>`. Note the `_` (underscore) instead of a `.` (dot), this approach was used because consul forbids the presence of dots in a service name or tag. If no `SERVICE_TAGS` is specified, the service will be available on **all** domains.
+
+Here is an complete example:
+```
+docker run -p 80 -e SERVICE_NAME=www -e SERVICE_TAGS=example_com,example_net webserver
+```
+This will make the webserver's 80 port accessible through request to `www.example.com` or `www.example.net`. Also note that requests to `example.com` or `example.com` will be redirected (302 permanent redirect) to the corresponding `www` subdomain.
+
 ## Running
-
-### Modes
-
-haproxy-consul can run in two different modes: forwarding either consul services
-(the default) or Marathon apps. This behavior is controlled by the
-`HAPROXY_MODE` variable, which should be set to `consul` or
-`marathon`.
-
-#### consul Configuration
-
-When `HAPROXY_MODE` is set to `consul`, haproxy-consul uses consul service names
-to set subdomains. No other configuration is required.
-
-#### Marathon Configuration
-
-When `HAPROXY_MODE` is set to `marathon`, haproxy-consul assumes that there will
-be app information in the `marathon` prefix of the Consul KV store. It was
-written to work with the information provided by
-[marathon-consul](https://github.com/CiscoCloud/marathon-consul).
-
-By default, haproxy will forward all Marathon-assigned ports. So if you specify
-that your application should own port 10000 in the "ports" member of the app
-JSON, haproxy will open port 10000 to direct traffic to your app. This works
-with auto-assigned ports (ports set to 0), as well. This is all automatic, you
-don't need to think about it other than to pull the ports from Marathon.
-
-However, if you want HTTP load balancing using the host header, you need a
-specify the following labels on your app:
-
-```
-{
-    "id": "hello-rails",
-    "cmd": "cd hello && bundle install && bundle exec unicorn -p $PORT",
-    "mem": 100,
-    "cpus": 1.0,
-    "instances": 1,
-    "uris": [
-        "http://downloads.mesosphere.com/tutorials/RailsHello.tgz"
-    ],
-    "env": {
-        "RAILS_ENV": "production"
-    },
-    "ports": [10000],
-    "labels": {
-        "HAPROXY_HTTP": "true",
-        "HTTP_PORT_IDX_0_NAME": "hello_rails",
-    }
-}
-```
-
-In this example (available at [`examples/rails.json`](examples/rails.json)), the
-hello-rails application is assigned port 10000. This is different from the
-service or host port of the app; it is a global value that Marathon tracks. This
-means that haproxy-consul will forward all TCP traffic to port 10000 to the app
-workers.
-
-When `HAPROXY_HTTP` is set to true and `HTTP_PORT_IDX_0_NAME` is set to a
-DNS-valid name Haproxy will forward all HTTP traffic with the host header (the
-name specified plus [`HAPROXY_DOMAIN`](#options)) to the app workers. This
-extends to as many ports as you'd care to give it in the form
-`HTTP_PORT_IDX_{port_number}_NAME`.
-
-This particular app results in something like the following haproxy
-configuration:
-
-```
-global
-    maxconn 256
-    debug
-
-defaults
-    mode tcp
-    timeout connect 5000ms
-    timeout client 50000ms
-    timeout server 50000ms
-
-# HTTP services
-frontend www
-    mode http
-    bind *:80
-
-    # files ACLs
-    acl host_hello_rails hdr(host) -i hello_rails.haproxy.service.consul
-    use_backend hello_rails_backend if host_hello_rails
-
-# files backends
-backend hello_rails_backend
-    mode http
-    server 1.2.3.4:49165 # TASK_RUNNING
-
-# TCP services
-listen hello-rails_10000
-    mode tcp
-    bind *:10000
-    server task_id 1.2.3.4:41965 # TASK_RUNNING
-```
-
 ### Usage
-
-If you don't want to configure wildcard dns, you can use xip.io. In this example, we are going to assume that the IP of your server is `180.19.20.21`, then all domains in `180.19.20.21.xip.io` will forward to your host.
-
 Start the container as follows:
-
 ```
-docker run --net=host --name=haproxy -d -e HAPROXY_DOMAIN=180.19.20.21.xip.io asteris/haproxy-consul
+docker run --net=host --name=haproxy -d asteris/haproxy-consul
 ```
-
-If you have wildcard DNS set up for your company (say at `*.mycompany.com`) use the following:
-
-```
-docker run --net=host --name=haproxy -d -e HAPROXY_DOMAIN=mycompany.com asteris/haproxy-consul
-```
-
 Now that it is set up, connect to an app:
-
 ```
 curl -L http://myapp.mycompany.com
 ```
-
 Or if you do not have a wildcard DNS:
-
 ```
 curl -L http://myapp.180.19.20.21.xip.io
 ```
@@ -168,19 +80,11 @@ curl -L http://myapp.180.19.20.21.xip.io
 If you want to override the config and template files, mount a volume and set the `CONSUL_CONFIG` environment variable before launch. In docker this can be accomplished with the `-e` option:
 
 ```
-docker run -v /host/config:/my_config -e CONSUL_CONFIG=/my_config -net=host --name=haproxy -d -e HAPROXY_DOMAIN=mycompany.com asteris/haproxy-consul
+docker run -v /host/config:/my_config -e CONSUL_CONFIG=/my_config -net=host --name=haproxy -d asteris/haproxy-consul
 ```
 
 If you need to have a root CA added so you can connect to Consul over SSL, mount
 a directory containing your root CA at `/usr/local/share/ca-certificates/`.
-
-Configure using the following environment variables:
-
-Variable | Description | Default
----------|-------------|---------
-`HAPROXY_DOMAIN` | The domain to match against | `haproxy.service.consul` (for `app.haproxy.service.consul`).
-`HAPROXY_MODE` | forward consul service or Marathon apps | `consul` (`marathon` also available, as described [above](#modes))
-`HAPROXY_USESSL` | Enable the SSL frontend (see [below](#ssl-termination)) | `false`
 
 consul-template variables:
 
@@ -192,28 +96,14 @@ Variable | Description | Default
 `CONSUL_LOGLEVEL` | Valid values are "debug", "info", "warn", and "err". | `debug`
 `CONSUL_TOKEN`    | The [Consul API token](http://www.consul.io/docs/internals/acl.html) | 
 
-consul KV variables:
-
-Variable | Description | Default
----------|-------------|---------
-`service/haproxy/maxconn` | maximum connections | 256
-`service/haproxy/timeouts/connect` | connect timeout | 5000ms
-`service/haproxy/timeouts/client` | client timeout | 50000ms
-`service/haproxy/timeouts/server` | server timeout | 50000ms
-
 ### SSL Termination
 
-If you wish to configure HAproxy to terminate incoming SSL connections, you must set the environment variable `HAPROXY_USESSL=true`, and mount your SSL certificate at `/haproxy/ssl.crt` - this file should contain both the SSL certificate and the private key to use (with no passphrase), in PEM format. You should also include any intermediate certificates in this bundle.
-
-If you do not provide an SSL certificate at container runtime, a self-signed certificate will be generated for the value of `*.HAPROXY_DOMAIN`.
+If you wish to configure HAproxy to terminate incoming SSL connections, you must set the environment variable `HAPROXY_USESSL=true`, and mount your SSL certificate at `/certs/` - this folder should contain all your certificates, each should contain both the SSL certificate and the private key to use (with no passphrase), in PEM format. You should also include any intermediate certificates in this bundle.
 
 For example:
 ```
-docker run -v /etc/ssl/wildcard.example.com.pem:/haproxy/ssl.crt -e HAPROXY_USESSL=true -e HAPROXY_DOMAIN=example.com --net=host --name=haproxy haproxy-consul
+docker run -v /etc/ssl/wildcard.example.com.pem:/certs/ssl.crt:ro --net=host --name=haproxy haproxy-consul
 ```
-
-You can also force that all incoming connections are redirected to HTTPS, by setting `HAPROXY_USESSL=force`.
-
 SSL termination is currently only available in 'consul' mode.
 
 # License

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ listen hello-rails_10000
     mode tcp
     bind *:10000
     server task_id 1.2.3.4:41965 # TASK_RUNNING
+```
 
 ## Options
 

--- a/config/haproxy.cfg
+++ b/config/haproxy.cfg
@@ -1,5 +1,5 @@
 template {
   source = "/consul-template/template.d/haproxy.tmpl"
   destination = "/haproxy/haproxy.cfg"
-  command = "/usr/sbin/haproxy -D -p /var/run/haproxy.pid  -f /haproxy/haproxy.cfg -sf $(cat /var/run/haproxy.pid) || true"
+  command = "/usr/sbin/haproxy -D -f /haproxy/haproxy.cfg -sf $(pidof haproxy)"
 }

--- a/launch.sh
+++ b/launch.sh
@@ -77,7 +77,7 @@ function launch_haproxy {
     # be started)
     [ -f /haproxy/haproxy.cfg ] && rm /haproxy/haproxy.cfg
 
-    ${CONSUL_TEMPLATE} -config ${CONSUL_CONFIG} \
+    exec ${CONSUL_TEMPLATE} -config ${CONSUL_CONFIG} \
                        -log-level ${CONSUL_LOGLEVEL} \
                        -wait ${CONSUL_MINWAIT}:${CONSUL_MAXWAIT} \
                        -consul ${CONSUL_CONNECT} ${ctargs} ${vars}

--- a/template/consul.tmpl
+++ b/template/consul.tmpl
@@ -1,6 +1,6 @@
 global
-    maxconn {{or (key "service/haproxy/maxconn") 256}}
     debug
+    maxconn 4000
     # Recommended SSL ciphers as per https://hynek.me/articles/hardening-your-web-servers-ssl-ciphers/
     ssl-default-bind-options no-sslv3
     ssl-default-bind-ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS
@@ -11,33 +11,50 @@ global
 
 defaults
     mode http
+    timeout connect 10000 # default 10 second time out if a backend is not found
+    timeout client 300000 # 5 min timeout for client
+    timeout server 300000 # 5 min timeout for server
     option forwardfor
     option http-server-close
-    timeout connect {{or (key "service/haproxy/timeouts/connect") "5000ms"}}
-    timeout client {{or (key "service/haproxy/timeouts/client") "50000ms"}}
-    timeout server {{or (key "service/haproxy/timeouts/server") "50000ms"}}
 
-### HTTP(S) frontend ###
 frontend www
     bind *:80
-    {{ if env "HAPROXY_USESSL" }}bind *:443 ssl crt /haproxy/ssl.crt{{ end }}
+    bind *:443 ssl crt /certs/
+# Generated automatically by consul-template
 
-    reqadd X-Forwarded-Proto:\ http if !{ ssl_fc }
-    reqadd X-Forwarded-Proto:\ https if { ssl_fc }
-    {{ if eq (env "HAPROXY_USESSL") "force" }}
-    # Redirect all non-secure connections to HTTPS
-    redirect scheme https if !{ ssl_fc }{{ end }}
+#tagged services, tag is use for domain information
+{{ range $tag, $services := services | byTag }}
+# www default redirect for domain {{ $tag |replaceAll "_" "." }}:
+    acl default_{{ $tag}} hdr(host) -i {{ $tag |replaceAll "_" "." }}
+    redirect prefix http://www.{{ $tag |replaceAll "_" "."}} if default_{{ $tag}}
+{{ end }}
 
-    # Generated automatically by consul-template
-{{ range services }}
-    acl host_{{ .Name }} hdr(host) -i {{ .Name }}.{{ or (env "HAPROXY_DOMAIN") "haproxy.service.consul" }} 
+{{ range $tag, $services := services | byTag }}
+# services for domain {{ $tag |replaceAll "_" "." }}:
+{{ range $services}}
+    acl host_{{ .Name }}_{{ $tag}} hdr(host) -i {{ .Name }}.{{ $tag |replaceAll "_" "." }}
+    use_backend {{ .Name }}_{{$tag}}_backend if host_{{ .Name }}_{{ $tag }}
+{{ end }}
+{{ end }}
+
+#not tagged services, the url starting part is used
+{{range services}}{{if eq (.Tags |len) 0 }}
+    acl host_{{ .Name }} hdr(host) -m beg {{ .Name }}.
     use_backend {{ .Name }}_backend if host_{{ .Name }}
-{{ end }}
+{{ end }}{{ end }}
 
+#backend definition for tagged services
+{{ range $tag, $services := services | byTag }}{{range $services}}
+backend {{ .Name }}_{{$tag}}_backend
+   http-request set-header X-Forwarded-Port %[dst_port]
+   http-request add-header X-Forwarded-Proto https if { ssl_fc }{{ range service (print $tag "." .Name) }}
+   server {{ .Node }} {{ .Address }}:{{ .Port }} check{{ end }}
+{{ end }}{{ end }}
 
-### Consul-configured backend services ###
-{{ range services }}
+#backend definition for untagged services
+{{ range services }}{{ if eq (.Tags |len) 0 }}
 backend {{ .Name }}_backend
-{{ range service .Name }}
-   server {{ .Node }}-{{ .Port }} {{ .Address }}:{{ .Port }}{{ end }}
-{{ end }}
+   http-request set-header X-Forwarded-Port %[dst_port]
+   http-request add-header X-Forwarded-Proto https if { ssl_fc }{{ range service .Name }}
+   server {{ .Node }} {{ .Address }}:{{ .Port }} check{{ end }}
+{{ end }}{{ end }}

--- a/template/consul.tmpl
+++ b/template/consul.tmpl
@@ -24,6 +24,12 @@ frontend www
     bind *:80
 {{ if env "HAPROXY_USESSL" }}    bind *:443 ssl crt /certs/ {{ end }}
 
+{{ if ne (service "letsencrypt" |len) 0 }}
+#there is a letsencrypt service redirecting acme-challenge
+acl letsencrypt-acl path_beg /.well-known/acme-challenge/
+use_backend letsencrypt_backend if letsencrypt-acl
+{{ end }}
+
 # Generated automatically by consul-template
 
 {{ if ne (service "letsencrypt" |len) 0 }}

--- a/template/consul.tmpl
+++ b/template/consul.tmpl
@@ -1,6 +1,7 @@
 global
     debug
     maxconn 4000
+{{ if env "HAPROXY_USESSL" }}
     # Recommended SSL ciphers as per https://hynek.me/articles/hardening-your-web-servers-ssl-ciphers/
     ssl-default-bind-options no-sslv3
     ssl-default-bind-ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS
@@ -8,6 +9,7 @@ global
     ssl-default-server-options no-sslv3
     ssl-default-server-ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS
     tune.ssl.default-dh-param 2048
+{{ end }}
 
 defaults
     mode http
@@ -19,7 +21,7 @@ defaults
 
 frontend www
     bind *:80
-    bind *:443 ssl crt /certs/
+{{ if env "HAPROXY_USESSL" }}    bind *:443 ssl crt /certs/{{ end }}
 # Generated automatically by consul-template
 
 #tagged services, tag is use for domain information
@@ -46,15 +48,15 @@ frontend www
 #backend definition for tagged services
 {{ range $tag, $services := services | byTag }}{{range $services}}
 backend {{ .Name }}_{{$tag}}_backend
-   http-request set-header X-Forwarded-Port %[dst_port]
-   http-request add-header X-Forwarded-Proto https if { ssl_fc }{{ range service (print $tag "." .Name) }}
+   http-request set-header X-Forwarded-Port %[dst_port]{{ if env "HAPROXY_USESSL" }}
+   http-request add-header X-Forwarded-Proto https if { ssl_fc }{{ end }}{{ range service (print $tag "." .Name) }}
    server {{ .Node }} {{ .Address }}:{{ .Port }} check{{ end }}
 {{ end }}{{ end }}
 
 #backend definition for untagged services
 {{ range services }}{{ if eq (.Tags |len) 0 }}
 backend {{ .Name }}_backend
-   http-request set-header X-Forwarded-Port %[dst_port]
-   http-request add-header X-Forwarded-Proto https if { ssl_fc }{{ range service .Name }}
+   http-request set-header X-Forwarded-Port %[dst_port]{{ if env "HAPROXY_USESSL" }}
+   http-request add-header X-Forwarded-Proto https if { ssl_fc }{{ end }}{{ range service .Name }}
    server {{ .Node }} {{ .Address }}:{{ .Port }} check{{ end }}
 {{ end }}{{ end }}

--- a/template/consul.tmpl
+++ b/template/consul.tmpl
@@ -21,8 +21,15 @@ defaults
 
 frontend www
     bind *:80
-{{ if env "HAPROXY_USESSL" }}    bind *:443 ssl crt /certs/{{ end }}
+{{ if env "HAPROXY_USESSL" }}    bind *:443 ssl crt /certs/ {{ end }}
+
 # Generated automatically by consul-template
+
+{{ if ne (service "letsencrypt" |len) 0 }}
+#there is a letsencrypt service redirecting acme-challenge
+acl letsencrypt-acl path_beg /.well-known/acme-challenge/
+use_backend letsencrypt_backend if letsencrypt-acl
+{{ end }}
 
 #tagged services, tag is use for domain information
 {{ range $tag, $services := services | byTag }}


### PR DESCRIPTION
Here are the many changes I made to haproxy-consul ;-)

The most important one is the support of multidomains and the removal of `HAPROXY_DOMAIN` to use `SERVICE_TAGS` instead (ref #18). Be aware that this is a breaking change. Maybe you could keep the `HAPROXY_DOMAIN` in the `consul.tmpl` file and use it if it's set.

I updated the `README.md`, I wacked the toc because I didn't find the markdown-toc tool and didn't want to leave it outdated. You might want to rework the README.md file it's getting kind of fat. Maybe some stuff could go to the wiki.
